### PR TITLE
Extend shared renovate-config and settings defaults

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,3 +1,4 @@
+_extends: .github
 # https://github.com/apps/settings
 # https://github.com/repository-settings/app
 
@@ -20,35 +21,3 @@ repository:
   
   enable_automated_security_fixes: true
   enable_vulnerability_alerts: true
-  
-labels:
-  - name: "bug"
-    color: "d73a4a"
-    description: "Something isn't working"
-  - name: "dependencies"
-    color: "C62109"
-    description: "Pull requests that update a dependency file"
-  - name: "documentation"
-    color: "0075ca"
-    description: "Improvements or additions to documentation"
-  - name: "duplicate"
-    color: "cfd3d7"
-    description: "This issue or pull request already exists"
-  - name: "enhancement"
-    color: "a2eeef"
-    description: "New feature or request"
-  - name: "good first issue"
-    color: "7057ff"
-    description: "Good for newcomers"
-  - name: "help wanted"
-    color: "008672"
-    description: "Extra attention is needed"
-  - name: "invalid"
-    color: "e4e669"
-    description: "This doesn't seem right"
-  - name: "question"
-    color: "d876e3"
-    description: "Further information is requested"
-  - name: "wontfix"
-    color: "#ffffff"
-    description: "This will not be worked on"

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "assignees": [
-    "modem7"
-  ],
-  "labels": [
-    "dependencies"
-  ],
-  "timezone": "Europe/London"
+  "extends": ["github>modem7/renovate-config"]
 }


### PR DESCRIPTION
## Summary
- Replace `renovate.json` with a single `extends` reference to the shared preset in [modem7/renovate-config](https://github.com/modem7/renovate-config), instead of duplicating the same Renovate boilerplate that's copy-pasted across ~15 of modem7's repos.
- Add `_extends: .github` to `.github/settings.yml` and drop the duplicated `labels:` array, since the label set is now inherited from the account-wide defaults in [modem7/.github](https://github.com/modem7/.github).

## Notes
- This depends on [modem7/renovate-config#6](https://github.com/modem7/renovate-config/pull/6) merging for the new `extends` target to have its intended (updated) content. Until #6 merges, `github>modem7/renovate-config` still resolves to the current config there, which is harmless — the extends reference itself is correct now and will pick up the new shared preset automatically once #6 lands.
- `modem7/.github`'s shared `labels:` defaults are already merged to its `master`, so the settings.yml change here takes effect immediately.

## Test plan
- [x] Validated with `npx --yes -p renovate renovate-config-validator` — "Config validated successfully"
- [x] Validated `.github/settings.yml` is well-formed YAML